### PR TITLE
Update ecpay_payment_sdk.py

### DIFF
--- a/sdk/ecpay_payment_sdk.py
+++ b/sdk/ecpay_payment_sdk.py
@@ -234,7 +234,8 @@ class BasePayment(object):
             else:
                 raise Exception('unsupported type!')
         for k, v in parameters.items():
-            if v.get('default'):
+            #if v.get('default'):
+            if 'default' in v:
                 default_dict[k] = v.get('default')
         return default_dict
 


### PR DESCRIPTION
修正錯誤：預設值為int且=0的時候會被略過，並不會自動填入